### PR TITLE
[codex] Improve repo health quick fixes

### DIFF
--- a/generate_report.py
+++ b/generate_report.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import json
 import os
 import random
+import sys
 from enum import Enum
 
 import openai
@@ -379,15 +380,16 @@ def convert_to_markdown(
     scientist, subject = acd_name.split("_")
     try:
         scientist, subject = MODEL_NAME[scientist], MODEL_NAME[subject]
-    except:
+    except KeyError:
         pass
 
     # Generate cluster visualization
     import subprocess
 
+    python_executable = sys.executable or "python"
     result = subprocess.run(
         [
-            "python",
+            python_executable,
             "src/visualize_generated_tasks_cluster.py",
             "--acd_name",
             acd_name,
@@ -400,6 +402,8 @@ def convert_to_markdown(
         text=True,
     )
     print(f"Visualization script output:\n{result.stdout}")
+    if result.stderr:
+        print(f"Visualization script stderr:\n{result.stderr}")
     cluster_vis_fig_path = os.path.abspath(f"reports/cluster_vis_{acd_name}.pdf")
     if not os.path.exists(cluster_vis_fig_path):
         print(
@@ -409,7 +413,7 @@ def convert_to_markdown(
     # Generate cluster success rate visualization
     result = subprocess.run(
         [
-            "python",
+            python_executable,
             "src/visualize_cluster_success_rate.py",
             "--acd_name",
             acd_name,
@@ -420,6 +424,8 @@ def convert_to_markdown(
         text=True,
     )
     print(f"Success rate visualization script output:\n{result.stdout}")
+    if result.stderr:
+        print(f"Success rate visualization script stderr:\n{result.stderr}")
     cluster_radar_fig_path = os.path.abspath(f"reports/cluster_radar_{acd_name}.pdf")
     if not os.path.exists(cluster_radar_fig_path):
         print(f"Warning: Cluster radar figure not found at {cluster_radar_fig_path}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pandas
 numpy
 backoff
 tqdm
-sklearn
+hdbscan
 # Plotting
 plotly
 matplotlib

--- a/src/llm_utils.py
+++ b/src/llm_utils.py
@@ -145,7 +145,7 @@ def get_batch_responses_from_llm(
                 model,
                 system_message,
                 print_debug=False,
-                msg_history=None,
+                msg_history=msg_history,
                 temperature=temperature,
             )
             content.append(c)

--- a/src/visualize_cluster_success_rate.py
+++ b/src/visualize_cluster_success_rate.py
@@ -7,6 +7,9 @@ from math import pi
 import matplotlib.pyplot as plt
 import numpy as np
 
+MODEL_NAME = {"gpt4": "GPT-4o", "llama": "Llama-8B", "sonnet": "Claude 3.5 Sonnet"}
+EVAL_THRESHOLD = 0.6
+
 
 def plot_cluster_radar_mpl(acd_name, model_cluster_stats, models):
     """
@@ -57,8 +60,7 @@ def plot_cluster_radar_mpl(acd_name, model_cluster_stats, models):
             rates.append(rate)
         rates.append(rates[0])  # close loop
 
-        legend_label = subject
-        ax.plot(angles, rates, label=legend_label, linewidth=2)
+        ax.plot(angles, rates, label=model, linewidth=2)
         ax.fill(angles, rates, alpha=0.15)
 
     # Offset so the "gap" is at 12 o'clock
@@ -114,77 +116,79 @@ def plot_cluster_radar_mpl(acd_name, model_cluster_stats, models):
     plt.tight_layout()
     plt.savefig(f"reports/cluster_radar_{acd_name}.pdf", dpi=300, bbox_inches="tight")
 
+def main():
+    parser = argparse.ArgumentParser(description="Visualize cluster success rates")
+    parser.add_argument(
+        "--acd_name",
+        type=str,
+        default="gpt4_gpt4",
+        help="ACD experiment name (e.g. gpt4_gpt4)",
+    )
+    parser.add_argument(
+        "--clustering_labels_path",
+        type=str,
+        required=True,
+        help="Path to clustering labels JSON file",
+    )
+    args = parser.parse_args()
 
-parser = argparse.ArgumentParser(description="Visualize cluster success rates")
-parser.add_argument(
-    "--acd_name",
-    type=str,
-    default="gpt4_gpt4",
-    help="ACD experiment name (e.g. gpt4_gpt4)",
-)
-parser.add_argument(
-    "--clustering_labels_path", type=str, help="Path to clustering labels JSON file"
-)
-args = parser.parse_args()
+    _, subject = args.acd_name.split("_", maxsplit=1)
+    subject = MODEL_NAME.get(subject, subject)
 
-MODEL_NAME = {"gpt4": "GPT-4o", "llama": "Llama-8B", "sonnet": "Claude 3.5 Sonnet"}
-scientist, subject = args.acd_name.split("_")
-try:
-    scientist, subject = MODEL_NAME[scientist], MODEL_NAME[subject]
-except:
-    pass
-eval_threshold = 0.6
-
-clustering_labels_path = args.clustering_labels_path
-if not os.path.exists(clustering_labels_path):
-    raise FileNotFoundError(f"Clustering results not found at {clustering_labels_path}")
-else:
+    clustering_labels_path = args.clustering_labels_path
+    if not os.path.exists(clustering_labels_path):
+        raise FileNotFoundError(
+            f"Clustering results not found at {clustering_labels_path}"
+        )
     print(f"Found clustering results at {clustering_labels_path}")
 
-# Load clustering results
-with open(clustering_labels_path, "r") as f:
-    clustering_data = json.load(f)
+    # Load clustering results
+    with open(clustering_labels_path, "r") as f:
+        clustering_data = json.load(f)
 
-# Create a mapping of task names to cluster info
-task_to_cluster = {}
-for item in clustering_data:
-    task_to_cluster[item["dir"]] = {
-        "cluster": item["cluster"],
-        "label": item["cluster_label"],
-        "capability": item["cluster_capability"],
-    }
+    # Create a mapping of task names to cluster info
+    task_to_cluster = {}
+    for item in clustering_data:
+        task_to_cluster[item["dir"]] = {
+            "cluster": item["cluster"],
+            "label": item["cluster_label"],
+            "capability": item["cluster_capability"],
+        }
 
-# Dictionary to store cluster-level stats
-cluster_stats = {}
-total_tasks = 0
-successful_tasks = 0
+    # Dictionary to store cluster-level stats
+    cluster_stats = {}
+    total_tasks = 0
+    successful_tasks = 0
 
-for task_dir, cluster_info in task_to_cluster.items():
-    # Get success rate from metadata
-    metadata_file = os.path.join(task_dir, "metadata.json")
-    if not os.path.exists(metadata_file):
-        continue
+    for task_dir, cluster_info in task_to_cluster.items():
+        # Get success rate from metadata
+        metadata_file = os.path.join(task_dir, "metadata.json")
+        if not os.path.exists(metadata_file):
+            continue
 
-    with open(metadata_file, "r") as f:
-        metadata = json.load(f)
-    success_rate = metadata.get("success_rate", 0)
+        with open(metadata_file, "r") as f:
+            metadata = json.load(f)
+        success_rate = metadata.get("success_rate", 0)
 
-    total_tasks += 1
-    if success_rate >= eval_threshold:
-        successful_tasks += 1
+        total_tasks += 1
+        if success_rate >= EVAL_THRESHOLD:
+            successful_tasks += 1
 
-    # Track cluster success
-    cluster_label = cluster_info["label"]
-    if cluster_label not in cluster_stats:
-        cluster_stats[cluster_label] = {"total": 0, "success": 0}
-    cluster_stats[cluster_label]["total"] += 1
-    if success_rate >= eval_threshold:
-        cluster_stats[cluster_label]["success"] += 1
+        # Track cluster success
+        cluster_label = cluster_info["label"]
+        if cluster_label not in cluster_stats:
+            cluster_stats[cluster_label] = {"total": 0, "success": 0}
+        cluster_stats[cluster_label]["total"] += 1
+        if success_rate >= EVAL_THRESHOLD:
+            cluster_stats[cluster_label]["success"] += 1
 
-model_cluster_stats = {subject: cluster_stats}
-overall_success_rate = successful_tasks / total_tasks if total_tasks > 0 else 0
-print(
-    f"Overall success rate: {overall_success_rate:.2%} ({successful_tasks}/{total_tasks})"
-)
-# Call the Matplotlib radar function
-plot_cluster_radar_mpl(args.acd_name, model_cluster_stats, [subject])
+    model_cluster_stats = {subject: cluster_stats}
+    overall_success_rate = successful_tasks / total_tasks if total_tasks > 0 else 0
+    print(
+        f"Overall success rate: {overall_success_rate:.2%} ({successful_tasks}/{total_tasks})"
+    )
+    plot_cluster_radar_mpl(args.acd_name, model_cluster_stats, [subject])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/visualize_generated_tasks_cluster.py
+++ b/src/visualize_generated_tasks_cluster.py
@@ -156,10 +156,12 @@ def main():
             cluster_int.append(matching_result["cluster"])
             cluster_names.append(matching_result["cluster_label"])
             cluster_capabilities.append(matching_result["cluster_capability"])
+            measured_capability = matching_result["cluster_capability"]
         else:
             cluster_int.append(-1)
             cluster_names.append("")
             cluster_capabilities.append("")
+            measured_capability = "Unknown"
 
         if not task.eval_answers:
             hover_str = f"Instructions: {task.instructions[0]}"
@@ -170,9 +172,7 @@ def main():
         else:
             hover_str = f"Instructions: {task.instructions[0]}"
 
-        hover_str += (
-            f"<br><br> Measured Capability: {matching_result['cluster_capability']}"
-        )
+        hover_str += f"<br><br> Measured Capability: {measured_capability}"
 
         # Split the hover text into multiple lines for better readability.
         spacing = 120


### PR DESCRIPTION
## Summary

This PR applies a small set of repo-health fixes discovered during a code-health pass.

- add the missing `hdbscan` dependency and remove the redundant `sklearn` entry
- make `visualize_cluster_success_rate.py` import-safe and remove its hidden global dependency
- use the active Python interpreter when report generation spawns helper scripts and surface helper stderr
- preserve message history in batched non-`gpt-4o` LLM calls
- avoid crashes in cluster visualization when a task has no matching cluster row

## Why

A few small robustness issues were making the repo harder to install and more brittle at runtime:

- fresh environments could miss `hdbscan` even though report generation imports it
- importing the radar chart script triggered CLI parsing immediately and relied on module-level state
- report generation could invoke a different Python interpreter than the one running the main script
- batched LLM calls could silently drop conversation context on some model paths
- cluster visualization assumed clustering metadata was always perfectly aligned with task rows

## Impact

These changes should make setup and reporting flows more predictable, reduce avoidable crashes, and improve internal helper correctness without changing the intended user-facing workflow.

## Validation

- `python -m compileall src *.py`
- `python - <<'PY'`
  `import src.visualize_cluster_success_rate`
  `print('IMPORT_OK')`
  `PY`
- `python src/visualize_cluster_success_rate.py --help`
